### PR TITLE
Treat Warnings as Errors

### DIFF
--- a/Devantler.SOPSCLI/Devantler.SOPSCLI.csproj
+++ b/Devantler.SOPSCLI/Devantler.SOPSCLI.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
This pull request adds the configuration to treat warnings as errors in the project. This ensures that any warnings generated during the build process will be treated as errors, preventing them from being ignored and promoting better code quality.