### PR TITLE
Update package reference for local age management

### DIFF
--- a/Devantler.SOPSCLI.Tests/Devantler.SOPSCLI.Tests.csproj
+++ b/Devantler.SOPSCLI.Tests/Devantler.SOPSCLI.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
-    <PackageReference Include="Devantler.KeyManager.Local.Age" Version="1.1.*" />
+    <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.1.*" />
     <PackageReference Include="Devantler.KubernetesGenerator.Native" Version="1.0.*" />
   </ItemGroup>
 


### PR DESCRIPTION
Replace the package reference from `Devantler.KeyManager.Local.Age` to `Devantler.SecretManager.SOPS.LocalAge` to ensure proper dependency management.